### PR TITLE
Enable multiple builds of lalapps with mpi flavours

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,14 +10,32 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_python2.7:
-        CONFIG: linux_python2.7
+      linux_mpimpichpython2.7:
+        CONFIG: linux_mpimpichpython2.7
         UPLOAD_PACKAGES: False
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_mpimpichpython3.6:
+        CONFIG: linux_mpimpichpython3.6
         UPLOAD_PACKAGES: False
-      linux_python3.7:
-        CONFIG: linux_python3.7
+      linux_mpimpichpython3.7:
+        CONFIG: linux_mpimpichpython3.7
+        UPLOAD_PACKAGES: False
+      linux_mpinompipython2.7:
+        CONFIG: linux_mpinompipython2.7
+        UPLOAD_PACKAGES: False
+      linux_mpinompipython3.6:
+        CONFIG: linux_mpinompipython3.6
+        UPLOAD_PACKAGES: False
+      linux_mpinompipython3.7:
+        CONFIG: linux_mpinompipython3.7
+        UPLOAD_PACKAGES: False
+      linux_mpiopenmpipython2.7:
+        CONFIG: linux_mpiopenmpipython2.7
+        UPLOAD_PACKAGES: False
+      linux_mpiopenmpipython3.6:
+        CONFIG: linux_mpiopenmpipython3.6
+        UPLOAD_PACKAGES: False
+      linux_mpiopenmpipython3.7:
+        CONFIG: linux_mpiopenmpipython3.7
         UPLOAD_PACKAGES: False
   steps:
   - script: |

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,14 +10,32 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_python2.7:
-        CONFIG: osx_python2.7
+      osx_mpimpichpython2.7:
+        CONFIG: osx_mpimpichpython2.7
         UPLOAD_PACKAGES: False
-      osx_python3.6:
-        CONFIG: osx_python3.6
+      osx_mpimpichpython3.6:
+        CONFIG: osx_mpimpichpython3.6
         UPLOAD_PACKAGES: False
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_mpimpichpython3.7:
+        CONFIG: osx_mpimpichpython3.7
+        UPLOAD_PACKAGES: False
+      osx_mpinompipython2.7:
+        CONFIG: osx_mpinompipython2.7
+        UPLOAD_PACKAGES: False
+      osx_mpinompipython3.6:
+        CONFIG: osx_mpinompipython3.6
+        UPLOAD_PACKAGES: False
+      osx_mpinompipython3.7:
+        CONFIG: osx_mpinompipython3.7
+        UPLOAD_PACKAGES: False
+      osx_mpiopenmpipython2.7:
+        CONFIG: osx_mpiopenmpipython2.7
+        UPLOAD_PACKAGES: False
+      osx_mpiopenmpipython3.6:
+        CONFIG: osx_mpiopenmpipython3.6
+        UPLOAD_PACKAGES: False
+      osx_mpiopenmpipython3.7:
+        CONFIG: osx_mpiopenmpipython3.7
         UPLOAD_PACKAGES: False
 
   steps:

--- a/.ci_support/linux_mpimpichpython2.7.yaml
+++ b/.ci_support/linux_mpimpichpython2.7.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- mpich
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/linux_mpimpichpython3.6.yaml
+++ b/.ci_support/linux_mpimpichpython3.6.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- mpich
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/linux_mpimpichpython3.7.yaml
+++ b/.ci_support/linux_mpimpichpython3.7.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- mpich
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/linux_mpinompipython2.7.yaml
+++ b/.ci_support/linux_mpinompipython2.7.yaml
@@ -1,17 +1,15 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
 gsl:
 - '2.4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+mpi:
+- nompi
 pin_run_as_build:
   gsl:
     max_pin: x.x
@@ -19,4 +17,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '2.7'

--- a/.ci_support/linux_mpinompipython3.6.yaml
+++ b/.ci_support/linux_mpinompipython3.6.yaml
@@ -8,6 +8,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.4'
+mpi:
+- nompi
 pin_run_as_build:
   gsl:
     max_pin: x.x
@@ -15,4 +17,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'

--- a/.ci_support/linux_mpinompipython3.7.yaml
+++ b/.ci_support/linux_mpinompipython3.7.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- nompi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/linux_mpiopenmpipython2.7.yaml
+++ b/.ci_support/linux_mpiopenmpipython2.7.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- openmpi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/linux_mpiopenmpipython3.6.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6.yaml
@@ -8,6 +8,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.4'
+mpi:
+- openmpi
 pin_run_as_build:
   gsl:
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.7.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+gsl:
+- '2.4'
+mpi:
+- openmpi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/osx_mpimpichpython2.7.yaml
+++ b/.ci_support/osx_mpimpichpython2.7.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/osx_mpimpichpython3.6.yaml
+++ b/.ci_support/osx_mpimpichpython3.6.yaml
@@ -12,6 +12,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- mpich
 pin_run_as_build:
   gsl:
     max_pin: x.x
@@ -19,4 +21,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'

--- a/.ci_support/osx_mpimpichpython3.7.yaml
+++ b/.ci_support/osx_mpimpichpython3.7.yaml
@@ -12,6 +12,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- mpich
 pin_run_as_build:
   gsl:
     max_pin: x.x

--- a/.ci_support/osx_mpinompipython2.7.yaml
+++ b/.ci_support/osx_mpinompipython2.7.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/osx_mpinompipython3.6.yaml
+++ b/.ci_support/osx_mpinompipython3.6.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/osx_mpinompipython3.7.yaml
+++ b/.ci_support/osx_mpinompipython3.7.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'

--- a/.ci_support/osx_mpiopenmpipython2.7.yaml
+++ b/.ci_support/osx_mpiopenmpipython2.7.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/.ci_support/osx_mpiopenmpipython3.6.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6.yaml
@@ -1,0 +1,24 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+gsl:
+- '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+pin_run_as_build:
+  gsl:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/osx_mpiopenmpipython3.7.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7.yaml
@@ -1,13 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-docker_image:
-- condaforge/linux-anvil-comp7
 gsl:
 - '2.4'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
 pin_run_as_build:
   gsl:
     max_pin: x.x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@
 version: 2
 
 jobs:
-  build_linux_python2.7:
+  build_linux_mpimpichpython2.7:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python2.7"
+      - CONFIG: "linux_mpimpichpython2.7"
     steps:
       - checkout
       - run:
@@ -22,11 +22,11 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.6:
+  build_linux_mpimpichpython3.6:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.6"
+      - CONFIG: "linux_mpimpichpython3.6"
     steps:
       - checkout
       - run:
@@ -39,11 +39,113 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.7:
+  build_linux_mpimpichpython3.7:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.7"
+      - CONFIG: "linux_mpimpichpython3.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpinompipython2.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpinompipython2.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpinompipython3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpinompipython3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpinompipython3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpinompipython3.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpiopenmpipython2.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpiopenmpipython2.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpiopenmpipython3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpiopenmpipython3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil-comp7
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_mpiopenmpipython3.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_mpiopenmpipython3.7"
     steps:
       - checkout
       - run:
@@ -61,6 +163,12 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_python2.7
-      - build_linux_python3.6
-      - build_linux_python3.7
+      - build_linux_mpimpichpython2.7
+      - build_linux_mpimpichpython3.6
+      - build_linux_mpimpichpython3.7
+      - build_linux_mpinompipython2.7
+      - build_linux_mpinompipython3.6
+      - build_linux_mpinompipython3.7
+      - build_linux_mpiopenmpipython2.7
+      - build_linux_mpiopenmpipython3.6
+      - build_linux_mpiopenmpipython3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,15 @@ osx_image: xcode9.4
 
 env:
   matrix:
-    - CONFIG=osx_python2.7
-    - CONFIG=osx_python3.6
-    - CONFIG=osx_python3.7
+    - CONFIG=osx_mpimpichpython2.7
+    - CONFIG=osx_mpimpichpython3.6
+    - CONFIG=osx_mpimpichpython3.7
+    - CONFIG=osx_mpinompipython2.7
+    - CONFIG=osx_mpinompipython3.6
+    - CONFIG=osx_mpinompipython3.7
+    - CONFIG=osx_mpiopenmpipython2.7
+    - CONFIG=osx_mpiopenmpipython3.6
+    - CONFIG=osx_mpiopenmpipython3.7
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+set -ex
+
+if [[ "${mpi}" == "nompi" ]]; then
+    MPI_ARGS="--disable-mpi"
+else
+    MPI_ARGS="--enable-mpi MPICC=${PREFIX}/bin/mpicc MPICXX=${PREFIX}/bin/mpicxx MPIFC=${PREFIX}/bin/mpifc"
+fi
+
 ./configure \
 	--prefix=${PREFIX} \
 	--disable-gcc-flags \
 	--enable-cfitsio \
 	--enable-openmp \
-	--enable-mpi \
-	MPICC=${PREFIX}/bin/mpicc \
-	MPICXX=${PREFIX}/bin/mpicxx \
-	MPIFC=${PREFIX}/bin/mpifc
+	${MPI_ARGS}
 
 make -j ${CPU_COUNT}
 make -j ${CPU_COUNT} check

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - nompi
+  - mpich  # [unix]
+  - openmpi  # [unix]
+
+pin_run_as_build:
+  mpich: x.x
+  openmpi: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,7 @@
 {% set version = "6.23.0" %}
 {% set sha256 = "e2c749ad3f326ef212f25f8f06d7a85a87903efeaf1f13163da40e27bde9f16e" %}
 
+# lalsuite versions
 {% set lal_version = "6.19.2" %}
 {% set lalburst_version = "1.5.1" %}
 {% set lalframe_version = "1.4.0" %}
@@ -10,6 +11,15 @@
 {% set lalmetaio_version = "1.5.0" %}
 {% set lalpulsar_version = "1.17.1" %}
 {% set lalsimulation_version = "1.8.2" %}
+
+# build number
+{% set build = 1 %}
+
+# set default build and build number based on mpi request
+{% set mpi = mpi or 'nompi' %}
+{% if mpi == 'openmpi' %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name }}
@@ -26,8 +36,14 @@ source:
     - searchsum2cache.patch
 
 build:
-  number: 1
+  number: {{ build }}
   skip: true  # [win]
+  {% if mpi != 'nompi' %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
 
 requirements:
   build:
@@ -48,7 +64,7 @@ requirements:
     - lalsimulation >={{ lalsimulation_version }}
     - libframe
     - metaio
-    - openmpi
+    - {{ mpi }}  # [mpi != "nompi"]
     - python
     - python-lal >={{ lal_version }}
     - python-lalburst >={{ lalburst_version }}
@@ -75,7 +91,7 @@ requirements:
     - libframe
     - ligo-segments
     - metaio
-    - openmpi
+    - {{ mpi }}  # [mpi != "nompi"]
     - numpy
     - pillow
     - python


### PR DESCRIPTION
This PR modifies the feedstock to build three different versions of lalapps (for each python version), providing each of `nompi`, `mpich`, and `openmpi` variants, similar to what is done for `hdf5`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
