### PR TITLE
ignore_run_exports from fftw to workaround conda-build issue

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -10,6 +12,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -10,6 +12,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -10,6 +12,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - clang
 c_compiler_version:
 - '4'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - clang
 c_compiler_version:
 - '4'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -4,12 +4,16 @@ c_compiler:
 - clang
 c_compiler_version:
 - '4'
+cfitsio:
+- '3.470'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,12 @@ source:
     - disable-weave-tests.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
+  ignore_run_exports:
+    # run_exports parsing for fftw is broken, so we ignore it
+    # manually, for now
+    - fftw
 
 requirements:
   build:
@@ -34,7 +38,7 @@ requirements:
     - pkg-config
   host:
     - cfitsio
-    - fftw
+    - fftw * nompi*
     - gsl
     - lal >={{ lal_version }}
     - lalburst >={{ lalburst_version }}
@@ -44,7 +48,7 @@ requirements:
     - lalmetaio >={{ lalmetaio_version }}
     - lalpulsar >={{ lalpulsar_version }}
     - lalsimulation >={{ lalsimulation_version }}
-    - libblas * *netlib
+    - libblas
     - libframe
     - llvm-openmp  # [osx]
     - metaio


### PR DESCRIPTION
`conda-build` currently can't properly handle the way that `fftw` uses `run_exports`, so we ignore it manually, this should probably be removed at some point when `conda-build` is updated accordingly.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
